### PR TITLE
Extend expense tracker functionality

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,6 @@
         "dockerfile": "../Dockerfile",
         "context": ".."
     },
-    "forwardPorts": [8000]
+    "forwardPorts": [8000, 8001],
+    "postStartCommand": "bash .devcontainer/start_services.sh"
 }

--- a/.devcontainer/start_services.sh
+++ b/.devcontainer/start_services.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+uvicorn backend.main:app --host 0.0.0.0 --port 8000 &
+python -m http.server 8001 --directory frontend &
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-
-Este repositorio contiene la base de una aplicación pensada para registrar gastos
-de forma privada. Incluye un pequeño backend en Python y una interfaz web
-sencilla a modo de demostración. En el futuro podría integrarse reconocimiento
-de voz e IA para capturar gastos con frases como "mete 10 euros en gastos de bar".
+Este repositorio contiene una pequeña aplicación para registrar gastos de forma privada. Incluye un backend en FastAPI con SQLite y un frontend muy sencillo en JavaScript.
 
 ## Estructura
-- `backend/` API con FastAPI y SQLite.
-- `frontend/` Aplicación web simple en JavaScript.
+- `backend/` API con FastAPI.
+- `frontend/` Aplicación web estática.
+- `.devcontainer/` configuración para VS Code.
+
+## Base de datos
+Al iniciar el backend se crea automáticamente la base de datos `expenses.db` con una estructura pensada para manejar familias y usuarios.
+Se genera una familia de ejemplo denominada *Familia root* con el usuario `root` (contraseña `test`). Este usuario dispone de una cuenta *Personal* y las categorías *Bares* y *Compra*.
 
 ## Primeros pasos
 
@@ -15,14 +16,31 @@ de voz e IA para capturar gastos con frases como "mete 10 euros en gastos de bar
    ```bash
    pip install -r backend/requirements.txt
    ```
-2. Iniciar el backend:
+2. Iniciar el backend manualmente:
    ```bash
    uvicorn backend.main:app --reload
    ```
-3. Abrir `frontend/index.html` en el navegador y probar la entrada de datos.
+3. En otra terminal servir el frontend:
+   ```bash
+   python -m http.server 8001 --directory frontend
+   ```
+4. Abrir `http://localhost:8001` en el navegador.
+
+### Dev container (VS Code)
+Para trabajar en un contenedor de desarrollo realiza los siguientes pasos:
+1. Instala la extensión **Dev Containers** en VS Code.
+2. Abre la paleta de comandos con `F1` o `Ctrl+Shift+P` y ejecuta
+   `Dev Containers: Open Folder in Container...` seleccionando este repositorio.
+3. VS Code construirá el contenedor definido en `.devcontainer` y abrirá la
+   carpeta dentro de él.
+4. Al iniciarse el contenedor se ejecutará `start_services.sh`, que levanta el
+   backend en el puerto 8000 y un servidor estático para el frontend en el
+   puerto 8001.
+5. Abre `http://localhost:8001` para usar la aplicación. La base de datos se
+   almacena en la carpeta del proyecto, por lo que persiste entre sesiones.
 
 ### Uso con Docker
-También puedes levantar la API en un contenedor Docker:
+Tambien se puede levantar la API en un contenedor Docker:
 1. Construir la imagen:
    ```bash
    docker build -t gastos-app .
@@ -31,9 +49,13 @@ También puedes levantar la API en un contenedor Docker:
    ```bash
    docker run --rm -p 8000:8000 gastos-app
    ```
-3. Acceder al frontend abriendo `frontend/index.html` y apuntando la API a `http://localhost:8000`.
+3. Servir el frontend por tu cuenta y apuntarlo a `http://localhost:8000`.
 
-Si utilizas Visual Studio Code, puedes abrir la carpeta en modo *dev container* para que la imagen se genere automáticamente.
+### Pruebas
+Se incluyen tests básicos para backend y frontend.
 
-Este proyecto es solo un punto de partida y se espera ampliarlo con
-funciones de voz, IA y una interfaz más trabajada.
+Ejecuta:
+```bash
+python backend/test_backend.py
+node frontend/test_frontend.js
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,40 +2,260 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List
 import sqlite3
+from hashlib import sha256
 
 app = FastAPI()
 
 DB_PATH = "expenses.db"
 
+
 def init_db():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(
-        "CREATE TABLE IF NOT EXISTS expenses (id INTEGER PRIMARY KEY, description TEXT, amount REAL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)"
+        """CREATE TABLE IF NOT EXISTS families (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        )"""
     )
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY,
+            family_id INTEGER,
+            username TEXT UNIQUE,
+            password TEXT,
+            FOREIGN KEY(family_id) REFERENCES families(id)
+        )"""
+    )
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS accounts (id INTEGER PRIMARY KEY, user_id INTEGER, name TEXT, FOREIGN KEY(user_id) REFERENCES users(id))"
+    )
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY, user_id INTEGER, name TEXT, FOREIGN KEY(user_id) REFERENCES users(id))"
+    )
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS expenses (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER,
+            account_id INTEGER,
+            category_id INTEGER,
+            description TEXT,
+            amount REAL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(user_id) REFERENCES users(id),
+            FOREIGN KEY(account_id) REFERENCES accounts(id),
+            FOREIGN KEY(category_id) REFERENCES categories(id)
+        )"""
+    )
+    # create default family and root user if not exist
+    c.execute("SELECT id FROM users WHERE username='root'")
+    row = c.fetchone()
+    if not row:
+        c.execute("INSERT INTO families (name) VALUES ('Familia root')")
+        family_id = c.lastrowid
+        hashed = sha256('test'.encode()).hexdigest()
+        c.execute(
+            "INSERT INTO users (family_id, username, password) VALUES (?, ?, ?)",
+            (family_id, 'root', hashed),
+        )
+        user_id = c.lastrowid
+        c.execute("INSERT INTO accounts (user_id, name) VALUES (?, ?)", (user_id, 'Personal'))
+        c.execute("INSERT INTO categories (user_id, name) VALUES (?, ?)", (user_id, 'Bares'))
+        c.execute("INSERT INTO categories (user_id, name) VALUES (?, ?)", (user_id, 'Compra'))
     conn.commit()
     conn.close()
+
 
 init_db()
 
+
+class Family(BaseModel):
+    id: int
+    name: str
+
+
+class FamilyCreate(BaseModel):
+    name: str
+
+
+class User(BaseModel):
+    id: int
+    family_id: int
+    username: str
+
+
+class UserCreate(BaseModel):
+    family_id: int
+    username: str
+    password: str
+
+
+@app.get("/families/", response_model=List[Family])
+def list_families():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT id, name FROM families")
+    rows = c.fetchall()
+    conn.close()
+    return [Family(id=r[0], name=r[1]) for r in rows]
+
+
+@app.post("/families/", response_model=Family)
+def create_family(family: FamilyCreate):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("INSERT INTO families (name) VALUES (?)", (family.name,))
+    conn.commit()
+    fam_id = c.lastrowid
+    conn.close()
+    return Family(id=fam_id, name=family.name)
+
+
+@app.get("/users/", response_model=List[User])
+def list_users():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT id, family_id, username FROM users")
+    rows = c.fetchall()
+    conn.close()
+    return [User(id=r[0], family_id=r[1], username=r[2]) for r in rows]
+
+
+@app.post("/users/", response_model=User)
+def create_user(user: UserCreate):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    hashed = sha256(user.password.encode()).hexdigest()
+    c.execute(
+        "INSERT INTO users (family_id, username, password) VALUES (?, ?, ?)",
+        (user.family_id, user.username, hashed),
+    )
+    conn.commit()
+    user_id = c.lastrowid
+    conn.close()
+    return User(id=user_id, family_id=user.family_id, username=user.username)
+
+
+class Account(BaseModel):
+    id: int
+    name: str
+
+
+class AccountCreate(BaseModel):
+    user_id: int
+    name: str
+
+
+class Category(BaseModel):
+    id: int
+    name: str
+
+
+class CategoryCreate(BaseModel):
+    user_id: int
+    name: str
+
+
 class Expense(BaseModel):
+    id: int
+    user_id: int
+    account_id: int
+    category_id: int
     description: str
     amount: float
 
-@app.post("/expenses/", response_model=Expense)
-def create_expense(expense: Expense):
+
+class ExpenseCreate(BaseModel):
+    user_id: int
+    account_id: int
+    category_id: int
+    description: str
+    amount: float
+
+
+@app.get("/accounts/", response_model=List[Account])
+def list_accounts():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute("INSERT INTO expenses (description, amount) VALUES (?, ?)", (expense.description, expense.amount))
-    conn.commit()
+    c.execute("SELECT id, name FROM accounts")
+    rows = c.fetchall()
     conn.close()
-    return expense
+    return [Account(id=r[0], name=r[1]) for r in rows]
+
+
+@app.post("/accounts/", response_model=Account)
+def create_account(account: AccountCreate):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO accounts (user_id, name) VALUES (?, ?)",
+        (account.user_id, account.name),
+    )
+    conn.commit()
+    acc_id = c.lastrowid
+    conn.close()
+    return Account(id=acc_id, name=account.name)
+
+
+@app.get("/categories/", response_model=List[Category])
+def list_categories():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute("SELECT id, name FROM categories")
+    rows = c.fetchall()
+    conn.close()
+    return [Category(id=r[0], name=r[1]) for r in rows]
+
+
+@app.post("/categories/", response_model=Category)
+def create_category(category: CategoryCreate):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO categories (user_id, name) VALUES (?, ?)",
+        (category.user_id, category.name),
+    )
+    conn.commit()
+    cat_id = c.lastrowid
+    conn.close()
+    return Category(id=cat_id, name=category.name)
+
+
+@app.post("/expenses/", response_model=Expense)
+def create_expense(expense: ExpenseCreate):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO expenses (user_id, account_id, category_id, description, amount) VALUES (?, ?, ?, ?, ?)",
+        (
+            expense.user_id,
+            expense.account_id,
+            expense.category_id,
+            expense.description,
+            expense.amount,
+        ),
+    )
+    conn.commit()
+    exp_id = c.lastrowid
+    conn.close()
+    return Expense(id=exp_id, **expense.dict())
+
 
 @app.get("/expenses/", response_model=List[Expense])
 def list_expenses():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute("SELECT description, amount FROM expenses")
+    c.execute("SELECT id, user_id, account_id, category_id, description, amount FROM expenses")
     rows = c.fetchall()
     conn.close()
-    return [Expense(description=row[0], amount=row[1]) for row in rows]
+    return [
+        Expense(
+            id=r[0],
+            user_id=r[1],
+            account_id=r[2],
+            category_id=r[3],
+            description=r[4],
+            amount=r[5],
+        )
+        for r in rows
+    ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pydantic
+httpx

--- a/backend/test_backend.py
+++ b/backend/test_backend.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+import main
+
+# ensure fresh database
+if os.path.exists(main.DB_PATH):
+    os.remove(main.DB_PATH)
+main.init_db()
+
+
+def test_flow():
+    fam = main.create_family(main.FamilyCreate(name='Fam1'))
+    user = main.create_user(main.UserCreate(family_id=fam.id, username='u1', password='pass'))
+    cat = main.create_category(main.CategoryCreate(user_id=user.id, name='Super'))
+    acc = main.create_account(main.AccountCreate(user_id=user.id, name='Cuenta'))
+    main.create_expense(main.ExpenseCreate(user_id=user.id, account_id=acc.id, category_id=cat.id, description='test', amount=5.0))
+    gastos = main.list_expenses()
+    assert any(e.description == 'test' for e in gastos)
+
+if __name__ == '__main__':
+    test_flow()
+    print('Backend tests passed')

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,5 +1,59 @@
 const form = document.getElementById('gasto-form');
 const lista = document.getElementById('gastos');
+const cuentas = document.getElementById('cuenta');
+const categorias = document.getElementById('categoria');
+const usuarioSel = document.getElementById('usuario');
+const familyForm = document.getElementById('family-form');
+const userForm = document.getElementById('user-form');
+const familySelect = document.getElementById('family-select');
+
+async function cargarOpciones() {
+    const famResp = await fetch('http://localhost:8000/families/');
+    const fams = await famResp.json();
+    fams.forEach(f => {
+        const opt = document.createElement('option');
+        opt.value = f.id;
+        opt.textContent = f.name;
+        familySelect.appendChild(opt.cloneNode(true));
+    });
+
+    const userResp = await fetch('http://localhost:8000/users/');
+    const users = await userResp.json();
+    users.forEach(u => {
+        const opt = document.createElement('option');
+        opt.value = u.id;
+        opt.textContent = u.username;
+        usuarioSel.appendChild(opt);
+    });
+
+    const accResp = await fetch('http://localhost:8000/accounts/');
+    const accounts = await accResp.json();
+    accounts.forEach(a => {
+        const opt = document.createElement('option');
+        opt.value = a.id;
+        opt.textContent = a.name;
+        cuentas.appendChild(opt);
+    });
+
+    const catResp = await fetch('http://localhost:8000/categories/');
+    const cats = await catResp.json();
+    cats.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c.id;
+        opt.textContent = c.name;
+        categorias.appendChild(opt);
+    });
+}
+
+async function cargarGastos() {
+    const resp = await fetch('http://localhost:8000/expenses/');
+    const gastos = await resp.json();
+    gastos.forEach(g => {
+        const item = document.createElement('li');
+        item.textContent = `${g.description} - ${g.amount}€`;
+        lista.appendChild(item);
+    });
+}
 
 form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -9,7 +63,13 @@ form.addEventListener('submit', async (e) => {
     await fetch('http://localhost:8000/expenses/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ description: descripcion, amount: cantidad })
+        body: JSON.stringify({
+            user_id: parseInt(usuarioSel.value),
+            account_id: parseInt(cuentas.value),
+            category_id: parseInt(categorias.value),
+            description: descripcion,
+            amount: cantidad
+        })
     });
 
     const item = document.createElement('li');
@@ -18,3 +78,33 @@ form.addEventListener('submit', async (e) => {
 
     form.reset();
 });
+
+familyForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = document.getElementById('family-name').value;
+    await fetch('http://localhost:8000/families/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+    });
+    location.reload();
+});
+
+userForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('userpass').value;
+    await fetch('http://localhost:8000/users/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            family_id: parseInt(familySelect.value),
+            username,
+            password
+        })
+    });
+    location.reload();
+});
+
+cargarOpciones();
+cargarGastos();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,24 @@
 </head>
 <body>
     <h1>Registro de Gastos</h1>
+    <h2>Nueva Familia</h2>
+    <form id="family-form">
+        <input type="text" id="family-name" placeholder="Nombre familia" required />
+        <button type="submit">Crear Familia</button>
+    </form>
+
+    <h2>Nuevo Usuario</h2>
+    <form id="user-form">
+        <select id="family-select"></select>
+        <input type="text" id="username" placeholder="Usuario" required />
+        <input type="password" id="userpass" placeholder="Contraseña" required />
+        <button type="submit">Crear Usuario</button>
+    </form>
+
     <form id="gasto-form">
+        <select id="usuario"></select>
+        <select id="cuenta"></select>
+        <select id="categoria"></select>
         <input type="text" id="descripcion" placeholder="Descripción" required />
         <input type="number" id="cantidad" placeholder="Cantidad" required />
         <button type="submit">Agregar</button>

--- a/frontend/test_frontend.js
+++ b/frontend/test_frontend.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const html = fs.readFileSync(__dirname + '/index.html', 'utf8');
+
+function expect(str, msg){
+  if(!html.includes(str)) throw new Error('Missing ' + msg);
+}
+
+expect('family-form', 'family form');
+expect('user-form', 'user form');
+expect('gasto-form', 'expense form');
+expect('usuario', 'user select');
+console.log('Frontend tests passed');
+


### PR DESCRIPTION
## Summary
- initialize devcontainer with backend and frontend servers
- add account and category tables
- create root user with default account and categories
- expose accounts, categories and expenses via new endpoints
- update frontend to select account and category
- document dev container usage and new database basics
- document how to work with VS Code dev container
- add families and multiple users
- store user for each expense
- expand frontend to create families and users and select user
- add backend and frontend tests

## Testing
- `python -m py_compile backend/main.py`
- `timeout 2s uvicorn backend.main:app --port 8000 --host 127.0.0.1`
- `python backend/test_backend.py`
- `node frontend/test_frontend.js`


------
https://chatgpt.com/codex/tasks/task_b_6863f93150848331a2827429b66f38cb