### PR TITLE
Add voice command expense entry

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8,6 +8,7 @@ const userForm = document.getElementById('user-form');
 const familySelect = document.getElementById('family-select');
 const familiesList = document.getElementById('familias');
 const selectedInfo = document.getElementById('selected-info');
+const voiceBtn = document.getElementById('voice-btn');
 
 let familiesData = [];
 let usersData = [];
@@ -156,6 +157,49 @@ userForm.addEventListener('submit', async (e) => {
     });
     location.reload();
 });
+
+function procesarComandoVoz(texto) {
+    const re = /inserta\s+(\d+(?:[\.,]\d+)?)\s*(?:euros|€)?\s+de\s+gastos\s+de\s+(\w+)\s+en\s+el\s+(\w+)/i;
+    const m = texto.match(re);
+    if (!m) {
+        console.warn('No se pudo interpretar el comando');
+        return;
+    }
+    const cantidad = parseFloat(m[1].replace(',', '.'));
+    const usuarioNom = m[2].toLowerCase();
+    const categoriaNom = m[3].toLowerCase();
+    const user = usersData.find(u => u.username.toLowerCase() === usuarioNom);
+    const catOption = Array.from(categorias.options).find(o => o.textContent.toLowerCase() === categoriaNom);
+    if (!user || !catOption) {
+        console.warn('Usuario o categoría no encontrados');
+        return;
+    }
+    usuarioSel.value = user.id;
+    categorias.value = catOption.value;
+    const desc = categoriaNom;
+    document.getElementById('descripcion').value = desc;
+    document.getElementById('cantidad').value = cantidad;
+    form.dispatchEvent(new Event('submit'));
+}
+
+function iniciarVoz() {
+    const SpeechRecognition = globalThis.SpeechRecognition || globalThis.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+        console.warn('Speech recognition not available');
+        return;
+    }
+    const recog = new SpeechRecognition();
+    recog.lang = 'es-ES';
+    recog.onresult = (e) => {
+        const texto = e.results[0][0].transcript;
+        procesarComandoVoz(texto);
+    };
+    recog.start();
+}
+
+if (voiceBtn && voiceBtn.addEventListener) {
+    voiceBtn.addEventListener('click', iniciarVoz);
+}
 
 cargarOpciones();
 cargarFamilias();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,6 +43,7 @@
                 <input type="text" id="descripcion" placeholder="Descripción" required />
                 <input type="number" id="cantidad" placeholder="Cantidad" required />
                 <button type="submit" class="primary">Agregar</button>
+                <button type="button" id="voice-btn" class="voice">Agregar por Voz</button>
             </form>
         </div>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -44,6 +44,13 @@ button.primary {
     border-radius: 4px;
 }
 
+button.voice {
+    background-color: #28a745;
+    color: white;
+    border: none;
+    border-radius: 4px;
+}
+
 .card {
     background: #fff;
     padding: 1em;

--- a/frontend/test_frontend.js
+++ b/frontend/test_frontend.js
@@ -17,7 +17,8 @@ const elements = {
   'username': { value: 'user1' },
   'userpass': { value: 'pass' },
   'family-select': { value: '1', appendChild() {} },
-  'familias': { innerHTML: '', appendChild(child) { this._child = child; } }
+  'familias': { innerHTML: '', appendChild(child) { this._child = child; } },
+  'voice-btn': { addEventListener(ev, cb) { if (ev === 'click') elements._voice = cb; } }
 };
 
 let created = [];
@@ -51,6 +52,7 @@ expect('family-form', 'family form');
 expect('user-form', 'user form');
 expect('gasto-form', 'expense form');
 expect('usuario', 'user select');
+expect('voice-btn', 'voice button');
 
 // Execute the front-end script in this context
 vm.runInThisContext(fs.readFileSync(__dirname + '/app.js', 'utf8'));


### PR DESCRIPTION
## Summary
- add voice button to record expenses using voice commands
- style the voice button
- parse simple Spanish speech commands on the front-end
- test presence of the new voice button

## Testing
- `node frontend/test_frontend.js`
- `python backend/test_backend.py`
- `node test_mobile.js`

------
https://chatgpt.com/codex/tasks/task_b_6867e3a043f8833181d04503317a49c2