### PR TITLE
Support more flexible voice commands

### DIFF
--- a/.devcontainer/install_android_sdk.sh
+++ b/.devcontainer/install_android_sdk.sh
@@ -19,4 +19,4 @@ yes | cmdline-tools/latest/bin/sdkmanager --licenses
 cmdline-tools/latest/bin/sdkmanager \
     "platform-tools" \
     "platforms;android-33" \
-    "build-tools;33.0.2"
+    "build-tools;35.0.0"

--- a/build_mobile.sh
+++ b/build_mobile.sh
@@ -12,6 +12,15 @@ if ! command -v gradle >/dev/null 2>&1; then
     apt-get update && apt-get install -y gradle && rm -rf /var/lib/apt/lists/*
 fi
 
+# Ensure recommended Android build tools
+REQUIRED_BT="35.0.0"
+if command -v sdkmanager >/dev/null 2>&1; then
+    if [ ! -d "$ANDROID_HOME/build-tools/$REQUIRED_BT" ]; then
+        echo "Instalando build-tools $REQUIRED_BT"
+        yes | sdkmanager "build-tools;$REQUIRED_BT" >/dev/null
+    fi
+fi
+
 # Setup Cordova project
 if [ ! -d mobile ]; then
     cordova create mobile com.expensetracker ExpenseTracker

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -172,17 +172,17 @@ userForm.addEventListener('submit', async (e) => {
 
 function procesarComandoVoz(texto) {
     logClient(`voz: ${texto}`);
-    const re = /inserta\s+(\d+(?:[\.,]\d+)?)\s*(?:euros|€)?\s+de\s+gastos\s+de\s+(\w+)\s+en\s+el\s+(\w+)/i;
+    const re = /(inserta|insertar)\s+€?\s*(\d+(?:[\.,]\d+)?)\s*€?\s+(?:de\s+gastos\s+)?(?:de|para)\s+(\w+)\s+en\s+(?:el|la|los|las)\s+(\w+)/i;
     const m = texto.match(re);
     if (!m) {
-        const ejemplo = 'inserta 5 euros de gastos de comida en el super';
+        const ejemplo = 'inserta 5€ de gastos para root en los bares';
         console.warn(`No se pudo interpretar el comando: "${texto}". Debe ser similar a "${ejemplo}"`);
         logClient(`Error: comando no coincide con la expresión. Recibido: "${texto}"`);
         return;
     }
-    const cantidad = parseFloat(m[1].replace(',', '.'));
-    const usuarioNom = m[2].toLowerCase();
-    const categoriaNom = m[3].toLowerCase();
+    const cantidad = parseFloat(m[2].replace(',', '.'));
+    const usuarioNom = m[3].toLowerCase();
+    const categoriaNom = m[4].toLowerCase();
     const user = usersData.find(u => u.username.toLowerCase() === usuarioNom);
     const catOption = Array.from(categorias.options).find(o => o.textContent.toLowerCase() === categoriaNom);
     if (!user || !catOption) {

--- a/test_mobile.js
+++ b/test_mobile.js
@@ -8,22 +8,46 @@ if (fs.existsSync(mobileDir)) {
   fs.rmSync(mobileDir, { recursive: true, force: true });
 }
 
-const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cordova-'));
-const stubPath = path.join(stubDir, 'cordova');
+const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stubs-'));
+const cordovaPath = path.join(stubDir, 'cordova');
 fs.writeFileSync(
-  stubPath,
+  cordovaPath,
   `#!/bin/sh
 if [ "$1" = "create" ]; then
   mkdir -p "$2/www"
+  exit 0
 fi
+if [ "$1" = "platform" ]; then
+  exit 0
+fi
+if [ "$1" = "build" ]; then
+  exit 0
+fi
+exit 0
 `
 );
-fs.chmodSync(stubPath, 0o755);
+fs.chmodSync(cordovaPath, 0o755);
+
+const gradlePath = path.join(stubDir, 'gradle');
+fs.writeFileSync(gradlePath, '#!/bin/sh\nexit 0\n');
+fs.chmodSync(gradlePath, 0o755);
+
+const sdkLog = path.join(stubDir, 'sdk.log');
+const sdkmanagerPath = path.join(stubDir, 'sdkmanager');
+fs.writeFileSync(sdkmanagerPath, `#!/bin/sh\necho "$@" >> "${sdkLog}"\n`);
+fs.chmodSync(sdkmanagerPath, 0o755);
+
+const androidHome = fs.mkdtempSync(path.join(os.tmpdir(), 'android-'));
 
 execFileSync('bash', ['build_mobile.sh', 'android'], {
-  env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+  env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}`, ANDROID_HOME: androidHome },
   stdio: 'inherit'
 });
+
+const logContent = fs.readFileSync(sdkLog, 'utf8');
+if (!logContent.includes('build-tools;35.0.0')) {
+  throw new Error('sdkmanager not called with build-tools 35.0.0');
+}
 
 if (!fs.existsSync(path.join(mobileDir, 'www', 'index.html'))) {
   throw new Error('mobile build failed');


### PR DESCRIPTION
## Summary
- loosen voice command regex in `frontend/app.js`
- accept `inserta/insertar`, optional `de gastos`, `de|para <usuario>`, and various articles before the category
- update example string and regex captures
- use Android build tools 35.0.0 and auto-install if missing
- test mobile build installs required build tools

## Testing
- `pytest backend/test_backend.py -q`
- `node frontend/test_frontend.js`
- `node test_mobile.js`

------
https://chatgpt.com/codex/tasks/task_b_6867e92b5de08331aef0a114355c1b97