### PR TITLE
Fix impersonation persistence

### DIFF
--- a/frontend/mis.js
+++ b/frontend/mis.js
@@ -4,6 +4,15 @@ const selectedInfo = document.getElementById('selected-info');
 let usersData = [];
 let familiesData = [];
 
+function setSelectedUser(id) {
+    usuarioSel.value = String(id);
+    try {
+        localStorage.setItem('selectedUserId', String(id));
+    } catch (e) {
+        /* ignore storage errors */
+    }
+}
+
 function updateSelectedInfo() {
     const userId = parseInt(usuarioSel.value);
     const user = usersData.find(u => u.id === userId);
@@ -26,6 +35,10 @@ async function cargarUsuarios() {
         opt.textContent = u.username;
         usuarioSel.appendChild(opt);
     });
+    const stored = localStorage.getItem('selectedUserId');
+    if (stored && usersData.find(u => u.id === parseInt(stored))) {
+        usuarioSel.value = stored;
+    }
     updateSelectedInfo();
     cargarGastos();
 }
@@ -42,6 +55,7 @@ async function cargarGastos() {
 }
 
 usuarioSel.addEventListener('change', () => {
+    setSelectedUser(parseInt(usuarioSel.value));
     updateSelectedInfo();
     cargarGastos();
 });


### PR DESCRIPTION
## Summary
- persist impersonated user across pages using localStorage
- avoid crash when `family-select` is missing
- update tests for persistence and missing element

## Testing
- `python backend/test_backend.py`
- `node frontend/test_frontend.js`
- `node test_mobile.js`


------
https://chatgpt.com/codex/tasks/task_b_686800f48adc8331a39c9592db8f767f